### PR TITLE
Enable build.rs to work on macOS

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,14 +2,13 @@ use std::process::Command;
 
 fn main() {
     let store = "store";
-    let _ = if cfg!(target_os = "linux") {
+    let _ = if cfg!(unix) {
         Command::new("sh")
             .arg("generate_certificates.sh")
             .arg(store)
             .output()
             .expect("failed to execute process");
-    }
-    else {
+    } else {
         Command::new("cmd")
             .args(&["./generate_certificates.sh", store])
             .output()


### PR DESCRIPTION
I changed the `cfg!` option in `build.rs` to allow for the library to build on macOS as well as Linux. I used the `unix` target_family instead of zeroing in on `linux` because I think it's safe to assume that a unix operating system would have `sh` to run the script to generate certs.